### PR TITLE
Fixing async issues and exposing both `plugins` and processing `options`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+## 1.2.0
+
+- Exposing `plugins` (passed directly to `postcss()`), and `options` (passed to `postcss().process(css, options)`)
+- Fixed async issues by wrapping in a promise and resolving the required Fly API result
+
 ## 1.1.0
 
 - Fix API, `processors` is in options.

--- a/index.js
+++ b/index.js
@@ -1,5 +1,23 @@
-module.exports = function () {
-  this.filter("postcss", (data, options) => ({
-    css: require("postcss")(options.processors).process(data.toString(), options).css
-  }))
+let postcss = require("postcss")
+
+module.exports = function() {
+    this.filter("postcss", (data, config) => {
+        // Combine our config with defaults using Object.assign
+        let fullConfig = Object.assign({}, { plugins: [], options: {} }, config)
+
+        // Return our promise out so we can wrap this async promise-based API
+        return new Promise((resolve, reject) => {
+            // Pull in the plugins list
+            postcss(fullConfig.plugins)
+                // Process the CSS with PostCSS and our options object passed to PostCSS
+                .process(data.toString(), fullConfig.options)
+                .then((result) => {
+                    // Resolve our CSS the way Fly expects it
+                    return resolve({ css: result.css })
+                })
+                .catch((err) => {
+                    return reject(err)
+                })
+        })
+    })
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fly-postcss",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Postcss plugin for Fly.",
   "license": "MIT",
   "repository": "https://github.com/morishitter/fly-postcss",
@@ -37,5 +37,10 @@
   "engines": {
     "iojs": ">= 1.0.0",
     "node": ">= 0.11.0"
-  }
+  },
+  "contributors": [{
+    "name": "Josh Girvin",
+    "email": "josh@jgirvin.com",
+    "url": "http://jgirvin.com"
+  }]
 }

--- a/readme.md
+++ b/readme.md
@@ -28,11 +28,15 @@ export default function* () {
   yield this
     .source('src/*.css')
     .postcss({
-      processors: [
-        require('cssnano')()
+      plugins: [
+        require('precss'),
+        require('autoprefixer')
       ],
-      from: 'a.css',
-      to: 'a.out.css'
+      options: {
+        parser: require('postcss-scss'),
+        from: 'a.css',
+        to: 'a.out.css'
+      }
     })
     .target('dist')
 }


### PR DESCRIPTION
This fixes #6, and exposes plugins array and `.process(css, options)` options. Works correctly with `this.source` and `this.target`, has been tested with `precss` and `postcss-scss` (used as `parser` in processing options), as well as `autoprefixer`