### PR TITLE
Updates to syntax for Fly 1.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,10 @@
-let postcss = require("postcss")
+var postcss = require("postcss")
+var assign = require("object-assign")
 
 module.exports = function() {
-    this.filter("postcss", (data, config) => {
+    this.filter("postcss", function (data, config) {
         // Combine our config with defaults using Object.assign
-        let fullConfig = Object.assign({}, { plugins: [], options: {} }, config)
+        let fullConfig = assign({}, { plugins: [], options: {} }, config)
 
         // Return our promise out so we can wrap this async promise-based API
         return new Promise((resolve, reject) => {

--- a/index.js
+++ b/index.js
@@ -4,19 +4,19 @@ var assign = require("object-assign")
 module.exports = function() {
     this.filter("postcss", function (data, config) {
         // Combine our config with defaults using Object.assign
-        let fullConfig = assign({}, { plugins: [], options: {} }, config)
+        config = assign({}, {plugins: [], options: {}}, config)
 
         // Return our promise out so we can wrap this async promise-based API
-        return new Promise((resolve, reject) => {
+        return new Promise(function (resolve, reject) {
             // Pull in the plugins list
-            postcss(fullConfig.plugins)
+            postcss(config.plugins)
                 // Process the CSS with PostCSS and our options object passed to PostCSS
-                .process(data.toString(), fullConfig.options)
-                .then((result) => {
+                .process(data.toString(), config.options)
+                .then(function (result) {
                     // Resolve our CSS the way Fly expects it
-                    return resolve({ css: result.css })
+                    return resolve({css: result.css})
                 })
-                .catch((err) => {
+                .catch(function (err) {
                     return reject(err)
                 })
         })

--- a/index.js
+++ b/index.js
@@ -2,7 +2,9 @@ var postcss = require("postcss")
 var assign = require("object-assign")
 
 module.exports = function() {
-    this.filter("postcss", function (data, config) {
+    var self = this
+    
+    self.filter("postcss", function (data, config) {
         // Combine our config with defaults using Object.assign
         config = assign({}, {plugins: [], options: {}}, config)
 
@@ -17,7 +19,10 @@ module.exports = function() {
                     return resolve({css: result.css})
                 })
                 .catch(function (err) {
-                    return reject(err)
+                    self.emit("plugin_error", {
+                      plugin: "fly-postcss",
+                      error: err
+                    })
                 })
         })
     })

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "url": "http://github.com/morishitter"
   },
   "dependencies": {
-    "postcss": "^5.0.3"
+    "postcss": "^5.0.3",
+    "object-assign": "^4.0.1"
   },
   "devDependencies": {
     "eslint": "^0.21.2",

--- a/readme.md
+++ b/readme.md
@@ -24,7 +24,7 @@ npm install -D fly-postcss
 ### Example
 
 ```js
-export default function* () {
+exports.default = function * () {
   yield this
     .source('src/*.css')
     .postcss({


### PR DESCRIPTION
Fly 1.0 lost innate ES6 support, for now. And although `fly-esnext` (wip) will allow for continued es6/7 support within plugins, it'd be better to support those who don't have the extension, if possible.

Includes `object-assign` ponyfill.

More explicit error handling. Sends the error directly to Fly rather than trusting `reject` will do the same.